### PR TITLE
On debug builds remove debug suffix from app id

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,6 @@ android {
             proguardFile getDefaultProguardFile('proguard-android.txt')
             shrinkResources false
             proguardFiles 'proguard-project.txt'
-            applicationIdSuffix '.debug'
             versionNameSuffix '-debug'
         }
 


### PR DESCRIPTION
For 'Play Billing' to work on debug builds, the application id should be the same as on the build uploaded on play store.