### PR TITLE
Insights dashboard improvements

### DIFF
--- a/app/src/main/java/com/cliqz/jsengine/JSBridge.java
+++ b/app/src/main/java/com/cliqz/jsengine/JSBridge.java
@@ -53,7 +53,7 @@ public class JSBridge extends ReactContextBaseJavaModule {
     private final Map<String, List<WaitingAction>> awaitingRegistration =
             new HashMap<>();
 
-    private static final long ACTION_TIMEOUT = 200;
+    private static final long ACTION_TIMEOUT = 1000;
 
     private final Handler handler;
     private final Bus bus;

--- a/app/src/main/java/com/cliqz/jsengine/WebRequest.java
+++ b/app/src/main/java/com/cliqz/jsengine/WebRequest.java
@@ -101,6 +101,31 @@ public class WebRequest extends ReactContextBaseJavaModule {
         return active;
     }
 
+    private JSBridge ensureBridge() {
+        try {
+            return engine.getBridge();
+        } catch (EngineNotYetAvailable e) {
+            Log.w("webrequest", "jsengine not yet loaded, waiting", e);
+            try {
+                Thread.sleep(250);
+            } finally {
+                return ensureBridge();
+            }
+        }
+    }
+
+    private ReadableMap triggerWebRequest(final WritableMap requestInfo) throws EmptyResponseException {
+        try {
+            return ensureBridge().callAction("webRequest", requestInfo);
+        } catch (ActionNotAvailable e) {
+            try {
+                Thread.sleep(200);
+            } finally {
+                return triggerWebRequest(requestInfo);
+            }
+        }
+    }
+
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public WebResourceResponse shouldInterceptRequest(final WebView view, final WebResourceRequest request,
                                                       boolean isPrivateTab) {
@@ -178,7 +203,7 @@ public class WebRequest extends ReactContextBaseJavaModule {
         requestInfo.putMap("requestHeaders", requestHeaders);
 
         try {
-            final ReadableMap response = engine.getBridge().callAction("webRequest", requestInfo);
+            final ReadableMap response = triggerWebRequest(requestInfo);
             final ReadableMap blockResponse = response.getMap("result");
             final String source = blockResponse.hasKey("source") ? blockResponse.getString("source") : "";
             // counter for tab
@@ -206,12 +231,8 @@ public class WebRequest extends ReactContextBaseJavaModule {
                 Log.d(TAG, "Modify request from: " + requestUrl.toString());
                 return modifyRequest(source, request, newUrl, modifiedHeaders);
             }
-        } catch (ActionNotAvailable e) {
-            Log.w("webrequest", "jsengine not ready yet", e);
         } catch (EmptyResponseException e) {
             Log.w("webrequest", "jsengine timed out", e);
-        } catch (EngineNotYetAvailable e) {
-            Log.w("webrequest", "jsengine not yet loaded", e);
         } catch (NoSuchKeyException e) {
             Log.e("webrequest", "error in jsengine response", e);
         }

--- a/app/src/main/java/com/cliqz/jsengine/WebRequest.java
+++ b/app/src/main/java/com/cliqz/jsengine/WebRequest.java
@@ -90,7 +90,15 @@ public class WebRequest extends ReactContextBaseJavaModule {
 
     private boolean isTabActive(final int tabId) {
         Pair<Uri, WeakReference<WebView>> tuple = tabs.get(tabId);
-        return tuple != null && tuple.second.get() != null;
+        final boolean active = tuple != null && tuple.second.get() != null;
+
+        if (!active) {
+            // send core:tab_close event to notify extension that tab is gone
+            final WritableMap tab = Arguments.createMap();
+            tab.putInt("tabId", tabId);
+            engine.publishEvent("core:tab_close", tab);
+        }
+        return active;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -160,6 +168,7 @@ public class WebRequest extends ReactContextBaseJavaModule {
         requestInfo.putString("originUrl", originUrl);
         requestInfo.putString("sourceUrl", originUrl);
         requestInfo.putString("frameUrl", originUrl);
+        requestInfo.putString("tabUrl", originUrl);
         requestInfo.putInt("type", contentPolicyType);
 
         final WritableMap requestHeaders = Arguments.createMap();

--- a/package-lock.json
+++ b/package-lock.json
@@ -3603,8 +3603,8 @@
       }
     },
     "browser-core": {
-      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/cliqz-android/v3.36/1.36.0.71ef1ae.tgz",
-      "integrity": "sha512-aa8l3PxbutuozYXvWNNySnPCZBBQ4tZYziXCEMQ5y77NoQeXfU3Iyey7eAuYO76wBltw3jd/sf25KEgL/L2L2g==",
+      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/cliqz-android/v3.36/1.36.0.364754b.tgz",
+      "integrity": "sha512-eiwHHt30HrfnH7OXhJmneYsEq3Ou4XgW9H3G1z+iuS3ryhE6QmoxAgvKHuCvShVZAbiM28/PoX+tyTprMjBigw==",
       "requires": {
         "@cliqz-oss/dexie": "^2.0.4",
         "@cliqz/adblocker": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/cliqz-oss/android-browser#readme",
   "dependencies": {
     "@cliqz/indexeddbshim": "^4.1.2",
-    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/cliqz-android/v3.36/1.36.0.71ef1ae.tgz",
+    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/cliqz-android/v3.36/1.36.0.364754b.tgz",
     "buffer": "5.0.7",
     "core-js": "2.5.3",
     "https-browserify": "1.0.0",


### PR DESCRIPTION
Fixes some issues with insights stats reporting:
 * Prevent double page counting on new tab
 * Count stats from closed tabs
 * Add stats from opened tabs when dashboard opened
 * Implement data volume saved using adblocker stats
 * Ensure all requests are sent to JSEngine on startup. This slows loading of restored tabs, but ensures that adblocking and anti-tracking run correctly for them, and stats get counted.